### PR TITLE
add flake.{nix|lock} for poetry2nix integration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,92 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1610051610,
+        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1645568708,
+        "narHash": "sha256-A1e4WvSDsUMZfV6XnyEqbRBhOcCzkgB1aZiMcQ/V/3s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d49b9ed896ce8989e6b491c61f5cfa06c78b7020",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1610729867,
+        "narHash": "sha256-bk/SBaBLqZX/PEqal27DMQwAHHl0dcZMp8NNksQr80s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "04af07c659c6723a2259bb6bc00a47ec53330f20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1645139622,
+        "narHash": "sha256-ahpapiZ59asavSgMqlvRoEL8eApsYQ9Xp3r5tiTbSTY=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "69cc39aa3b84c57eebc202b591c5876429e569a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "poetry2nix": "poetry2nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "Application packaged using poetry2nix";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+  inputs.poetry2nix.url = "github:nix-community/poetry2nix";
+
+  outputs = { self, nixpkgs, flake-utils, poetry2nix }:
+  let
+    # python39 doesn't seem to work because of the the setuptools not understanding environment
+    # marker like 'typing-extensions>=3.10.0.0; python_version < "3.10"' 
+    pythonDrvName = "python310";
+  in {
+      # Nixpkgs overlay providing the application
+      overlay = nixpkgs.lib.composeManyExtensions [
+        poetry2nix.overlay
+        (final: prev: {
+          poetry = prev.poetry.override { python = final.${pythonDrvName}; };
+          # The application
+          myapp = prev.poetry2nix.mkPoetryApplication {
+            projectDir = ./.;
+            python = final.${pythonDrvName};
+          };
+        })
+      ];
+    } // (flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ self.overlay ];
+        };
+      in
+      {
+        apps = {
+          myapp = pkgs.myapp;
+        };
+
+        defaultApp = pkgs.myapp;
+
+        devShell = (pkgs.poetry2nix.mkPoetryEnv {
+          projectDir = ./.;
+          editablePackageSources = {
+            myapp = ./thehodl;
+          };
+          python = pkgs.${pythonDrvName};
+        }).env;
+      }));
+}


### PR DESCRIPTION
Here is a kind of minimal poetry2nix setup. You can
```bash
> nix develop
```
to enter your dev setup. A relevant portion you need to understand in `flake.nix` is just
```nix
# ...
        devShell = (pkgs.poetry2nix.mkPoetryEnv {
          projectDir = ./.;
          editablePackageSources = {
            myapp = ./thehodl;
          };
          python = pkgs.${pythonDrvName};
        }).env;
# ...
```
.